### PR TITLE
Fix: Bug#126 flutter_ume_kit_dio_plus failed to parse request headers

### DIFF
--- a/kits/flutter_ume_kit_dio/lib/src/widgets/pluggable_state.dart
+++ b/kits/flutter_ume_kit_dio/lib/src/widgets/pluggable_state.dart
@@ -233,7 +233,7 @@ class _ResponseCardState extends State<_ResponseCard> {
     final Map<String, List<String>> map = _request.headers.map(
       (key, value) => MapEntry(
         key,
-        value is Iterable ? value.map((v) => v.toString()).toList() : [value],
+        value is Iterable ? value.map((v) => v.toString()).toList() : [value.toString()],
       ),
     );
     final Headers headers = Headers.fromMap(map);


### PR DESCRIPTION
修复问题：https://github.com/bytedance/flutter_ume/issues/126


Describe what problem this pull request solves and how to solve it. If there is an issue associated with it, please attach a link.

请描述这个 pull request 解决了什么问题，以及解决方式。如果有与之关联的 issue，请附链接。

## Pull Request Checklist

- [ ] I have read the [UME contribution document](../CONTRIBUTING.md) and understand how to contribute, commit the code according to the rules. 我已阅读过 UME 贡献文档，并了解如何进行贡献，按照规则提交了代码
- [ ] I have added the necessary comments in code to ensure that other contributors can understand the reason for the change. 我在修改中已经添加了必要的注释，以确保便于其他贡献者理解修改原因
- [ ] The code has been formatted by dartfmt before push. 代码在提交前已经经过 dartfmt 进行了格式化
- [ ] Change does not involve the adjustment of test cases. Or all existing and new tests are passing. 改动不涉及测试用例调整，或 example 工程与单元测试已经完全跑通

If you need help, consider [Join ing the ByteDance Flutter Exchange Group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8).

如有任何问题，可以[加入字节跳动 Flutter 交流群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=67au2f75-3783-41b0-8868-0fc0178f1fd8)。

Or contact [author](mailto:sunkai.dev@bytedance.com).

或随时[联系开发者](mailto:sunkai.dev@bytedance.com)。
